### PR TITLE
fix: lookup filesystem labels on the actual device path

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-11-15T13:22:12Z by kres c4d092b.
+# Generated on 2022-03-28T13:15:04Z by kres 8bc4139-dirty.
 
 ---
 policies:
@@ -10,7 +10,7 @@ policies:
     gpg:
       required: true
       identity:
-        gitHubOrganization: talos-systems
+        gitHubOrganization: siderolabs
     spellcheck:
       locale: US
     maximumOfOneCommit: true

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-11-15T13:22:12Z by kres c4d092b.
+# Generated on 2022-03-28T13:15:04Z by kres 8bc4139-dirty.
 
 # common variables
 
@@ -9,7 +9,7 @@ TAG := $(shell git describe --tag --always --dirty)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 ARTIFACTS := _out
 REGISTRY ?= ghcr.io
-USERNAME ?= talos-systems
+USERNAME ?= siderolabs
 REGISTRY_AND_USERNAME ?= $(REGISTRY)/$(USERNAME)
 GOFUMPT_VERSION ?= abc0db2c416aca0f60ea33c23c76665f6e7ba0b6
 GO_VERSION ?= 1.17
@@ -18,7 +18,7 @@ GRPC_GO_VERSION ?= 1.1.0
 GRPC_GATEWAY_VERSION ?= 2.4.0
 VTPROTOBUF_VERSION ?= 81d623a9a700ede8ef765e5ab08b3aa1f5b4d5a8
 TESTPKGS ?= ./...
-KRES_IMAGE ?= ghcr.io/talos-systems/kres:latest
+KRES_IMAGE ?= ghcr.io/siderolabs/kres:latest
 
 # docker build settings
 

--- a/blockdevice/probe/probe.go
+++ b/blockdevice/probe/probe.go
@@ -43,11 +43,10 @@ func WithPartitionLabel(label string) SelectOption {
 	}
 }
 
-// WithFileSystemLabel search for a block device which has filesystem on root level
-// and that filesystem is labeled as provided label.
+// WithFileSystemLabel searches for a block device which has filesystem labeled with the provided label.
 func WithFileSystemLabel(label string) SelectOption {
 	return func(device *ProbedBlockDevice) (bool, error) {
-		superblock, err := filesystem.Probe(device.Device().Name())
+		superblock, err := filesystem.Probe(device.Path)
 		if err != nil {
 			return false, err
 		}

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -2,11 +2,11 @@
 
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2021-11-15T13:22:12Z by kres c4d092b.
+# Generated on 2022-03-28T13:13:16Z by kres 8bc4139-dirty.
 
 set -e
 
-RELEASE_TOOL_IMAGE="ghcr.io/talos-systems/release-tool:latest"
+RELEASE_TOOL_IMAGE="ghcr.io/siderolabs/release-tool:latest"
 
 function release-tool {
   docker pull "${RELEASE_TOOL_IMAGE}" >/dev/null


### PR DESCRIPTION
The problem was that device path was used, which skips partition as
filesystem label is searched only on the blockdevices.

Add more tests for probe with filesystem labels.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>