### PR TITLE
fix: align partition to 1M boundary by default

### DIFF
--- a/blockdevice/lba/lba.go
+++ b/blockdevice/lba/lba.go
@@ -8,6 +8,9 @@ import (
 	"os"
 )
 
+// RecommendedAlignment is recommended alignment for LBA.
+const RecommendedAlignment = 1048576
+
 // LBA represents logical block addressing.
 //
 //nolint:govet
@@ -23,18 +26,28 @@ type LBA struct {
 }
 
 // AlignToPhysicalBlockSize aligns LBA value in LogicalBlockSize multiples to be aligned to PhysicalBlockSize.
-func (l *LBA) AlignToPhysicalBlockSize(lba uint64) uint64 {
+func (l *LBA) AlignToPhysicalBlockSize(lba uint64, roundUp bool) uint64 {
 	physToLogical := uint64(l.PhysicalBlockSize / l.LogicalBlockSize)
 	minIOToLogical := uint64(l.MinimalIOSize / l.LogicalBlockSize)
+	recommended := uint64(RecommendedAlignment / l.LogicalBlockSize)
 
+	// find max ratio
 	ratio := physToLogical
 	if minIOToLogical > ratio {
 		ratio = minIOToLogical
+	}
+
+	if recommended > ratio {
+		ratio = recommended
 	}
 
 	if ratio <= 1 {
 		return lba
 	}
 
-	return (lba + ratio - 1) / ratio * ratio
+	if roundUp {
+		return (lba + ratio - 1) / ratio * ratio
+	}
+
+	return lba / ratio * ratio
 }

--- a/blockdevice/lba/lba_test.go
+++ b/blockdevice/lba/lba_test.go
@@ -12,34 +12,52 @@ import (
 	"github.com/talos-systems/go-blockdevice/blockdevice/lba"
 )
 
-func TestAlignToPhysicalBlockSize(t *testing.T) {
+func TestAlignToRecommended(t *testing.T) {
 	l := lba.LBA{ //nolint: exhaustivestruct
-		PhysicalBlockSize: 4096,
-		LogicalBlockSize:  512,
-	}
-
-	assert.EqualValues(t, 0, l.AlignToPhysicalBlockSize(0))
-	assert.EqualValues(t, 8, l.AlignToPhysicalBlockSize(1))
-	assert.EqualValues(t, 8, l.AlignToPhysicalBlockSize(2))
-	assert.EqualValues(t, 8, l.AlignToPhysicalBlockSize(3))
-	assert.EqualValues(t, 8, l.AlignToPhysicalBlockSize(4))
-	assert.EqualValues(t, 8, l.AlignToPhysicalBlockSize(8))
-	assert.EqualValues(t, 16, l.AlignToPhysicalBlockSize(9))
-}
-
-func TestAlignToMinIOkSize(t *testing.T) {
-	l := lba.LBA{ //nolint: exhaustivestruct
-		MinimalIOSize:     262144,
 		PhysicalBlockSize: 512,
 		LogicalBlockSize:  512,
 	}
 
-	assert.EqualValues(t, 0, l.AlignToPhysicalBlockSize(0))
-	assert.EqualValues(t, 512, l.AlignToPhysicalBlockSize(1))
-	assert.EqualValues(t, 512, l.AlignToPhysicalBlockSize(2))
-	assert.EqualValues(t, 512, l.AlignToPhysicalBlockSize(3))
-	assert.EqualValues(t, 512, l.AlignToPhysicalBlockSize(4))
-	assert.EqualValues(t, 512, l.AlignToPhysicalBlockSize(8))
-	assert.EqualValues(t, 512, l.AlignToPhysicalBlockSize(512))
-	assert.EqualValues(t, 1024, l.AlignToPhysicalBlockSize(513))
+	assert.EqualValues(t, 0, l.AlignToPhysicalBlockSize(0, true))
+	assert.EqualValues(t, 2048, l.AlignToPhysicalBlockSize(1, true))
+	assert.EqualValues(t, 2048, l.AlignToPhysicalBlockSize(2, true))
+	assert.EqualValues(t, 2048, l.AlignToPhysicalBlockSize(3, true))
+	assert.EqualValues(t, 2048, l.AlignToPhysicalBlockSize(4, true))
+	assert.EqualValues(t, 2048, l.AlignToPhysicalBlockSize(2048, true))
+	assert.EqualValues(t, 4096, l.AlignToPhysicalBlockSize(2049, true))
+	assert.EqualValues(t, 2048, l.AlignToPhysicalBlockSize(2049, false))
+}
+
+func TestAlignToPhysicalBlockSize(t *testing.T) {
+	l := lba.LBA{ //nolint: exhaustivestruct
+		PhysicalBlockSize: 2 * 1048576,
+		LogicalBlockSize:  512,
+	}
+
+	assert.EqualValues(t, 0, l.AlignToPhysicalBlockSize(0, true))
+	assert.EqualValues(t, 4096, l.AlignToPhysicalBlockSize(1, true))
+	assert.EqualValues(t, 4096, l.AlignToPhysicalBlockSize(2, true))
+	assert.EqualValues(t, 4096, l.AlignToPhysicalBlockSize(3, true))
+	assert.EqualValues(t, 4096, l.AlignToPhysicalBlockSize(4, true))
+	assert.EqualValues(t, 4096, l.AlignToPhysicalBlockSize(4096, true))
+	assert.EqualValues(t, 8192, l.AlignToPhysicalBlockSize(4097, true))
+	assert.EqualValues(t, 4096, l.AlignToPhysicalBlockSize(4097, false))
+}
+
+func TestAlignToMinIOkSize(t *testing.T) {
+	l := lba.LBA{ //nolint: exhaustivestruct
+		MinimalIOSize:     4 * 1048576,
+		PhysicalBlockSize: 512,
+		LogicalBlockSize:  512,
+	}
+
+	assert.EqualValues(t, 0, l.AlignToPhysicalBlockSize(0, true))
+	assert.EqualValues(t, 8192, l.AlignToPhysicalBlockSize(1, true))
+	assert.EqualValues(t, 8192, l.AlignToPhysicalBlockSize(2, true))
+	assert.EqualValues(t, 8192, l.AlignToPhysicalBlockSize(3, true))
+	assert.EqualValues(t, 8192, l.AlignToPhysicalBlockSize(4, true))
+	assert.EqualValues(t, 8192, l.AlignToPhysicalBlockSize(8, true))
+	assert.EqualValues(t, 8192, l.AlignToPhysicalBlockSize(8192, true))
+	assert.EqualValues(t, 16384, l.AlignToPhysicalBlockSize(8193, true))
+	assert.EqualValues(t, 8192, l.AlignToPhysicalBlockSize(8193, false))
 }

--- a/blockdevice/partition/gpt/gpt.go
+++ b/blockdevice/partition/gpt/gpt.go
@@ -263,10 +263,10 @@ func (g *GPT) InsertAt(idx int, size uint64, setters ...PartitionOption) (*Parti
 	// Find partition boundaries.
 	var start, end uint64
 
-	start = g.l.AlignToPhysicalBlockSize(minLBA)
+	start = g.l.AlignToPhysicalBlockSize(minLBA, true)
 
 	if opts.MaximumSize {
-		end = maxLBA
+		end = g.l.AlignToPhysicalBlockSize(maxLBA+1, false) - 1
 
 		if end < start {
 			return nil, outOfSpaceError{fmt.Errorf("requested partition with maximum size, but no space available")}
@@ -338,6 +338,7 @@ func (g *GPT) Resize(part *Partition) (bool, error) {
 	}
 
 	maxLBA := g.h.LastUsableLBA
+	maxLBA = g.l.AlignToPhysicalBlockSize(maxLBA+1, false) - 1
 
 	for i := idx + 1; i < len(g.e.p); i++ {
 		if g.e.p[i] != nil {

--- a/blockdevice/probe/probe.go
+++ b/blockdevice/probe/probe.go
@@ -84,6 +84,8 @@ func WithSingleResult() SelectOption {
 			return false, fmt.Errorf("got more than one blockdevice with provided criteria")
 		}
 
+		count++
+
 		return true, nil
 	}
 }

--- a/blockdevice/probe/probe_test.go
+++ b/blockdevice/probe/probe_test.go
@@ -94,7 +94,7 @@ func (suite *ProbeSuite) TestProbeByPartitionLabel() {
 	suite.addPartition("test", size)
 	suite.addPartition("test2", size)
 
-	probed, err := probe.All(probe.WithPartitionLabel("test"))
+	probed, err := probe.All(probe.WithPartitionLabel("test"), probe.WithSingleResult())
 	suite.Require().NoError(err)
 	suite.Require().Equal(1, len(probed))
 


### PR DESCRIPTION
See e.g. https://www.thomas-krenn.com/en/wiki/Partition_Alignment_detailed_explanation

This is the default used by modern disk partition utilities.

Align partition end as well to the same boundary when the partition is
grown to the maximum size (see
https://github.com/siderolabs/talos/issues/4985).

Fix the problem with `WithSingleResult` which never worked properly (?).

It looks like `probe.All` the way it is designed will never work
properly, as the partition name check is done for the blockdevice as a
whole, while the iteration goes over all partition. This goes unnoticed
because of the way this function is actually used.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>