### PR TITLE
feat: add freebsd stubs

### DIFF
--- a/blockdevice/blkpg/blkpg_freebsd.go
+++ b/blockdevice/blkpg/blkpg_freebsd.go
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package blkpg
+
+import (
+	"fmt"
+	"os"
+)
+
+// InformKernelOfAdd invokes the BLKPG_ADD_PARTITION ioctl.
+func InformKernelOfAdd(f *os.File, first, length uint64, n int32) error {
+	return fmt.Errorf("not implemented")
+}
+
+// InformKernelOfResize invokes the BLKPG_RESIZE_PARTITION ioctl.
+func InformKernelOfResize(f *os.File, first, length uint64, n int32) error {
+	return fmt.Errorf("not implemented")
+}
+
+// InformKernelOfDelete invokes the BLKPG_DEL_PARTITION ioctl.
+func InformKernelOfDelete(f *os.File, first, length uint64, n int32) error {
+	return fmt.Errorf("not implemented")
+}
+
+// GetKernelPartitions returns kernel partition table state.
+func GetKernelPartitions(f *os.File) ([]KernelPartition, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/blockdevice/blockdevice_freebsd.go
+++ b/blockdevice/blockdevice_freebsd.go
@@ -1,0 +1,87 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package blockdevice
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/talos-systems/go-blockdevice/blockdevice/partition/gpt"
+)
+
+// BlockDevice represents a block device.
+type BlockDevice struct {
+	table *gpt.GPT
+
+	f *os.File
+}
+
+const (
+	// ReadonlyMode readonly mode.
+	ReadonlyMode = os.O_RDONLY
+	// DefaultMode read write.
+	DefaultMode = os.O_RDWR
+)
+
+// Open initializes and returns a block device.
+// TODO(andrewrynhard): Use BLKGETSIZE ioctl to get the size.
+func Open(devname string, setters ...Option) (bd *BlockDevice, err error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// Close closes the block devices's open file.
+func (bd *BlockDevice) Close() error {
+	return fmt.Errorf("not implemented")
+}
+
+// PartitionTable returns the block device partition table.
+func (bd *BlockDevice) PartitionTable() (*gpt.GPT, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// RereadPartitionTable invokes the BLKRRPART ioctl to have the kernel read the
+// partition table.
+//
+// NB: Rereading the partition table requires that all partitions be
+// unmounted or it will fail with EBUSY.
+func (bd *BlockDevice) RereadPartitionTable() error {
+	return fmt.Errorf("not implemented")
+}
+
+// Device returns the backing file for the block device.
+func (bd *BlockDevice) Device() *os.File {
+	return nil
+}
+
+// Size returns the size of the block device in bytes.
+func (bd *BlockDevice) Size() (uint64, error) {
+	return 0, fmt.Errorf("not implemented")
+}
+
+// Reset will reset a block device given a device name.
+// Simply deletes partition table on device.
+func (bd *BlockDevice) Reset() error {
+	return fmt.Errorf("not implemented")
+}
+
+// Wipe the blockdevice contents.
+func (bd *BlockDevice) Wipe() error {
+	return fmt.Errorf("not implemented")
+}
+
+// OpenPartition opens another blockdevice using a partition of this block device.
+func (bd *BlockDevice) OpenPartition(label string, setters ...Option) (*BlockDevice, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// GetPartition returns partition by label if found.
+func (bd *BlockDevice) GetPartition(label string) (*gpt.Partition, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// PartPath returns partition path by label, verifies that partition exists.
+func (bd *BlockDevice) PartPath(label string) (string, error) {
+	return "", fmt.Errorf("not implemented")
+}

--- a/blockdevice/lba/lba_freebsd.go
+++ b/blockdevice/lba/lba_freebsd.go
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package lba
+
+import (
+	"fmt"
+	"os"
+)
+
+// NewLBA initializes and returns an `LBA`.
+func NewLBA(f *os.File) (lba *LBA, err error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// ReadAt reads from a file in units of LBA.
+func (l *LBA) ReadAt(lba, off, length int64) (b []byte, err error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// WriteAt writes to a file in units of LBA.
+func (l *LBA) WriteAt(lba, off int64, b []byte) (err error) {
+	return fmt.Errorf("not implemented")
+}


### PR DESCRIPTION
This PR adds the same stubs that we use for darwin/windows to freebsd.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>