### PR TITLE
feat: support LUKS token management

### DIFF
--- a/blockdevice/encryption/luks/token.go
+++ b/blockdevice/encryption/luks/token.go
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package luks
+
+import "encoding/json"
+
+// Token defines LUKS2 token.
+type Token[UserData any] struct {
+	UserData UserData `json:",inline"`
+	Type     string   `json:"type"`
+}
+
+// Bytes encodes token into bytes.
+func (t *Token[UserData]) Bytes() ([]byte, error) {
+	return json.Marshal(struct {
+		*Token[UserData] `json:",inline"`
+		KeySlots         []string `json:"keyslots"`
+	}{Token: t, KeySlots: []string{}})
+}
+
+// Decode reads token data from bytes.
+func (t *Token[UserData]) Decode(in []byte) error {
+	return json.Unmarshal(in, &t)
+}

--- a/blockdevice/encryption/provider.go
+++ b/blockdevice/encryption/provider.go
@@ -6,6 +6,8 @@ package encryption
 
 import (
 	"fmt"
+
+	"github.com/siderolabs/go-blockdevice/blockdevice/encryption/token"
 )
 
 const (
@@ -17,6 +19,7 @@ const (
 
 // Provider represents encryption utility methods.
 type Provider interface {
+	TokenProvider
 	Encrypt(devname string, key *Key) error
 	Open(devname string, key *Key) (string, error)
 	Close(devname string) error
@@ -27,11 +30,23 @@ type Provider interface {
 	ReadKeyslots(deviceName string) (*Keyslots, error)
 }
 
-// ErrEncryptionKeyRejected triggered when encryption key does not match.
-var ErrEncryptionKeyRejected = fmt.Errorf("encryption key rejected")
+// TokenProvider represents token management methods.
+type TokenProvider interface {
+	SetToken(devname string, slot int, token token.Token) error
+	ReadToken(devname string, slot int, token token.Token) error
+	RemoveToken(devname string, slot int) error
+}
 
-// ErrDeviceBusy returned when mapped device is still in use.
-var ErrDeviceBusy = fmt.Errorf("mapped device is still in use")
+var (
+	// ErrEncryptionKeyRejected triggered when encryption key does not match.
+	ErrEncryptionKeyRejected = fmt.Errorf("encryption key rejected")
+
+	// ErrDeviceBusy returned when mapped device is still in use.
+	ErrDeviceBusy = fmt.Errorf("mapped device is still in use")
+
+	// ErrTokenNotFound returned when trying to get/delete not existing token.
+	ErrTokenNotFound = fmt.Errorf("no token with supplied id exists")
+)
 
 // Keyslots represents LUKS2 keyslots metadata.
 type Keyslots struct {

--- a/blockdevice/encryption/token/token.go
+++ b/blockdevice/encryption/token/token.go
@@ -1,0 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Package token contains token management interfaces.
+package token
+
+// Token defines luks token interface.
+type Token interface {
+	Bytes() ([]byte, error)
+	Decode(in []byte) error
+}


### PR DESCRIPTION
Ecryption provider gets 3 new methods:

- `SetToken` - creates/updates token in the LUKS metadata.
- `ReadToken` - reads token from the LUKS metadata.
- `RemoveToken` - removes token from the LUKS metadata.

Library supports 1 token per 1 keyslot to simplify management. If the key slot is removed it's token is removed too.