### PR TITLE
fix: do not attach token to a key slot

### DIFF
--- a/blockdevice/encryption/luks/luks.go
+++ b/blockdevice/encryption/luks/luks.go
@@ -306,7 +306,7 @@ func (l *LUKS) SetToken(devname string, slot int, token token.Token) error {
 
 	id := fmt.Sprintf("%d", slot)
 
-	_, err = l.runCommand([]string{"token", "import", "-q", devname, "--key-slot", id, "--token-id", id, "--json-file=-", "--token-replace"}, data)
+	_, err = l.runCommand([]string{"token", "import", "-q", devname, "--token-id", id, "--json-file=-", "--token-replace"}, data)
 
 	return err
 }


### PR DESCRIPTION
When attached to keyslot it is not possible to add token before adding the key.
Adding the key first might lead losing access to the partition if we get powerloss between writing the key and token update.