### PR TITLE
feat: luks resize

### DIFF
--- a/blockdevice/encryption/luks/luks.go
+++ b/blockdevice/encryption/luks/luks.go
@@ -171,6 +171,16 @@ func (l *LUKS) Encrypt(deviceName string, key *encryption.Key) error {
 	return err
 }
 
+// Resize implements encryption.Provider.
+func (l *LUKS) Resize(devname string, key *encryption.Key) error {
+	args := []string{"resize", devname, "--key-file=-"}
+	args = append(args, keyslotArgs(key)...)
+
+	_, err := l.runCommand(args, key.Value)
+
+	return err
+}
+
 // Close implements encryption.Provider.
 func (l *LUKS) Close(devname string) error {
 	_, err := l.runCommand([]string{"luksClose", devname}, nil)

--- a/blockdevice/encryption/luks/luks_test.go
+++ b/blockdevice/encryption/luks/luks_test.go
@@ -79,6 +79,9 @@ func (suite *LUKSSuite) TestEncrypt() {
 	encryptedPath, err := provider.Open(path, key)
 	suite.Require().NoError(err)
 
+	err = provider.Resize(encryptedPath, key)
+	suite.Require().NoError(err)
+
 	suite.Require().NoError(provider.AddKey(path, key, keyExtra))
 	suite.Require().NoError(provider.SetKey(path, keyExtra, keyExtra))
 	valid, err := provider.CheckKey(path, keyExtra)


### PR DESCRIPTION
Hello.

This small feature allow to us resize the LUKS partitions.
Talos at first boot resizes partitions if they already formatted. (if i am not mistaken)
It helps in future use encrypted images as image template.

Also I am trying to use this module here https://github.com/sergelogvinov/proxmox-csi-plugin/pull/75

Thanks.