### PR TITLE
fix: define softraid partition

### DIFF
--- a/blockdevice/util/util.go
+++ b/blockdevice/util/util.go
@@ -24,6 +24,10 @@ func PartNo(partname string) (string, error) {
 		idx := strings.LastIndex(partname, "p")
 
 		return partname[idx+1:], nil
+	case strings.HasPrefix(p, "md"):
+		idx := strings.LastIndex(partname, "p")
+
+		return partname[idx+1:], nil
 	case strings.HasPrefix(p, "sd"):
 		fallthrough
 	case strings.HasPrefix(p, "hd"):
@@ -57,6 +61,8 @@ func DevnameFromPartname(partname string) (string, error) {
 		fallthrough
 	case strings.HasPrefix(p, "loop"):
 		return strings.TrimSuffix(p, "p"+partno), nil
+	case strings.HasPrefix(p, "md"):
+		return strings.TrimSuffix(p, "p"+partno), nil
 	case strings.HasPrefix(p, "sd"):
 		fallthrough
 	case strings.HasPrefix(p, "hd"):
@@ -80,6 +86,8 @@ func PartName(d string, n int) string {
 	case strings.HasPrefix(p, "mmcblk"):
 		fallthrough
 	case strings.HasPrefix(p, "loop"):
+		partname = fmt.Sprintf("%sp%d", p, n)
+	case strings.HasPrefix(p, "md"):
 		partname = fmt.Sprintf("%sp%d", p, n)
 	default:
 		partname = fmt.Sprintf("%s%d", p, n)

--- a/blockdevice/util/util_test.go
+++ b/blockdevice/util/util_test.go
@@ -119,6 +119,13 @@ func Test_PartNo(t *testing.T) {
 			},
 			want: "3",
 		},
+		{
+			name: "md0p2",
+			args: args{
+				devname: "md0p2",
+			},
+			want: "2",
+		},
 	}
 
 	for _, tt := range tests {
@@ -205,6 +212,14 @@ func Test_DevnameFromPartname(t *testing.T) {
 				partno:  "3",
 			},
 			want: "mmcblk0",
+		},
+		{
+			name: "md0p1",
+			args: args{
+				devname: "md0p1",
+				partno:  "1",
+			},
+			want: "md0",
 		},
 	}
 


### PR DESCRIPTION
Hello. small fix.

MDRaid uses `p` betwewn device name and partition number.

Thanks.