### PR TITLE
fix: don't coerce to int

### DIFF
--- a/block/device_linux.go
+++ b/block/device_linux.go
@@ -22,9 +22,9 @@ func (d *Device) GetSize() (uint64, error) {
 
 // GetIOSize returns blockdevice optimal I/O size in bytes.
 func (d *Device) GetIOSize() (uint, error) {
-	for _, ioctl := range []int{unix.BLKIOOPT, unix.BLKIOMIN, unix.BLKBSZGET} {
+	for _, ioctl := range []uintptr{unix.BLKIOOPT, unix.BLKIOMIN, unix.BLKBSZGET} {
 		var size uint
-		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, d.f.Fd(), uintptr(ioctl), uintptr(unsafe.Pointer(&size))); errno != 0 {
+		if _, _, errno := unix.Syscall(unix.SYS_IOCTL, d.f.Fd(), ioctl, uintptr(unsafe.Pointer(&size))); errno != 0 {
 			continue
 		}
 


### PR DESCRIPTION
unix.BLKBSZGET overflows int32, breaking compilation on 32-bit systems. Since a uintptr is needed, coerce the constants directly to uintptr instead of coercing first to a signed int.