### PR TITLE
fix: don't ignore error on partition delete

### DIFF
--- a/partitioning/gpt/gpt.go
+++ b/partitioning/gpt/gpt.go
@@ -630,8 +630,10 @@ func (t *Table) syncKernel() error {
 			}
 
 			continue
-		case err != nil:
-			return fmt.Errorf("failed to delete partition %d: %w", no, err)
+		default:
+			if err != nil {
+				return fmt.Errorf("failed to delete partition %d: %w", no, err)
+			}
 		}
 
 		err = t.dev.KernelPartitionAdd(no,


### PR DESCRIPTION
There is subtle issue with return code 'EBUSY' while myEntry is nil, which might not fall through into this code to report an error correctly.